### PR TITLE
make bool of/to_url_query consistent with other types

### DIFF
--- a/native/runtime/ppx_deriving_router_primitives.ml
+++ b/native/runtime/ppx_deriving_router_primitives.ml
@@ -41,11 +41,11 @@ let int_of_url_query k xs =
         | None -> Error "not an integer value"
         | Some x -> Ok x))
 
-let bool_to_url_query k x = if x then [ k, "true" ] else []
+let bool_to_url_query k x = if x then [ k, "true" ] else [ k, "false" ]
 
 let bool_of_url_query k xs =
   last_wins k xs (function
-    | None -> Ok false
+    | None -> Error "missing value"
     | Some "true" -> Ok true
     | Some "false" -> Ok false
     | _ -> Error "not a boolean value (true, false)")


### PR DESCRIPTION
Currently, a `false` boolean value is omitted when transformed to a query param

```ocaml
type t =
  | About of { active : bool }
[@@deriving router]

let () =
  print_endline (Pages.href (About { active = false })) (* /About *)
```

Now it's being transformed to `/About?active=false`

If we want to be able to omit the value, we can still use a `bool option`

