### PR TITLE
avoid generating extra let binding if no query params

### DIFF
--- a/native/ppx_deriving_router_common.ml
+++ b/native/ppx_deriving_router_common.ml
@@ -386,7 +386,10 @@ module Derive_href = struct
                   [%e acc]]
               in
               let body = f body q in
-              List.fold_left qs ~init:body ~f
+              let body = List.fold_left qs ~init:body ~f in
+              [%expr
+                let [%p psep] = ref '?' in
+                [%e body]]
         in
         let body =
           List.fold_left (List.rev path) ~init:body ~f:(fun acc param ->
@@ -409,7 +412,6 @@ module Derive_href = struct
         let body =
           [%expr
             let [%p pout] = Buffer.create 16 in
-            let [%p psep] = ref '?' in
             [%e body]]
         in
         let bnds =


### PR DESCRIPTION
I noticed the following (unused) binding was generated even for routes with no query params

```ocaml
let _sep__038_ = ref '?' in
```

This PR should fix it. I don't think this is a big deal anyway so feel free to close.

For the following input:

```ocaml
module Pages = struct
  open Ppx_deriving_router_runtime.Primitives

  type t =
    | Home
    | About [@GET "/about"]
    | Echo of { test : bool; nb : int }
    | Project of { id : int } [@GET "/project/:id"]
    | Hello of { name : string; repeat : int option } [@GET "/hello/:name"]
  [@@deriving router]
end
```

Here's the diff

```diff
diff --git a/src/server/server2.ml b/src/server/server2.ml
index 86798f9..b1c1e24 100644
--- a/src/server/server2.ml
+++ b/src/server/server2.ml
@@ -18,22 +18,20 @@ module Pages = struct
       (function
        | Home ->
            let out__026_ = Buffer.create 16 in
-           let _sep__027_ = ref '?' in
            Buffer.add_char out__026_ '/';
            Ppx_deriving_router_runtime.Encode.encode_path out__026_ "Home";
            Buffer.contents out__026_
        | About ->
            let out__028_ = Buffer.create 16 in
-           let _sep__029_ = ref '?' in
            Buffer.add_char out__028_ '/';
            Ppx_deriving_router_runtime.Encode.encode_path out__028_ "about";
            Buffer.contents out__028_
        | Echo _x__030_ ->
            let test = _x__030_.test and nb = _x__030_.nb in
            let out__031_ = Buffer.create 16 in
-           let _sep__032_ = ref '?' in
            Buffer.add_char out__031_ '/';
            Ppx_deriving_router_runtime.Encode.encode_path out__031_ "Echo";
+           let _sep__032_ = ref '?' in
            Stdlib.List.iter
              (fun (name, value) ->
                Buffer.add_char out__031_ !_sep__032_;
@@ -58,7 +56,6 @@ module Pages = struct
        | Project _x__033_ ->
            let id = _x__033_.id in
            let out__034_ = Buffer.create 16 in
-           let _sep__035_ = ref '?' in
            Buffer.add_char out__034_ '/';
            Ppx_deriving_router_runtime.Encode.encode_path out__034_ "project";
            Buffer.add_char out__034_ '/';
@@ -68,12 +65,12 @@ module Pages = struct
        | Hello _x__036_ ->
            let name = _x__036_.name and repeat = _x__036_.repeat in
            let out__037_ = Buffer.create 16 in
-           let _sep__038_ = ref '?' in
            Buffer.add_char out__037_ '/';
            Ppx_deriving_router_runtime.Encode.encode_path out__037_ "hello";
            Buffer.add_char out__037_ '/';
            Ppx_deriving_router_runtime.Encode.encode_path out__037_
              (string_to_url_path name);
+           let _sep__038_ = ref '?' in
            Stdlib.List.iter
              (fun (name, value) ->
                Buffer.add_char out__037_ !_sep__038_;
diff --git a/vendor/ppx_deriving_router b/vendor/ppx_deriving_router
index 79d88e1..c35ea0d 160000
--- a/vendor/ppx_deriving_router
```

